### PR TITLE
Add page to edit profiles

### DIFF
--- a/src/FE/FEsrc/components/AdvancedFormField.tsx
+++ b/src/FE/FEsrc/components/AdvancedFormField.tsx
@@ -50,6 +50,7 @@ const AdvancedFormField: React.FC<AdvancedFormFieldProps> = ({
             <TextInput
                 type={fieldInfo.inputType}
                 value={value}
+                checked={value}
                 style={{width: 30, height: 30}}
                 onChange={(e) => {
                     setAdvancedInfo({ ...advancedInfo, [fieldVariable]: e.target.checked})

--- a/src/FE/FEsrc/components/App.tsx
+++ b/src/FE/FEsrc/components/App.tsx
@@ -14,6 +14,7 @@ import TrialSearchPage from '../pages/TrialSearchPage';
 import SaveTrialsPage from '../pages/SavedTrialsPage';
 import ProfileCreationPage from '../pages/ProfileCreation';
 import ListProfiles from '../pages/ListProfiles';
+import EditProfilePage from '../pages/EditProfilePage';
 
 function App() {
 
@@ -32,6 +33,7 @@ function App() {
                     <Route path='/savedTrials' element={<SaveTrialsPage />} />
                     <Route path='/createProfile' element={<ProfileCreationPage />} /> 
                     <Route path='/listprofiles' element={<ListProfiles />} />
+                    <Route path='/editProfile' element={<EditProfilePage />} /> 
                 </Routes>
             </BrowserRouter>
         </AuthProvider>

--- a/src/FE/FEsrc/components/UserProfileCard.tsx
+++ b/src/FE/FEsrc/components/UserProfileCard.tsx
@@ -1,22 +1,33 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-
+import { PatientInfo } from './types';
 interface UserProfileCardProps {
-  name: string;
-  condition: string;
+  profile: PatientInfo;
 }
 
-const UserProfileCard: React.FC<UserProfileCardProps> = ({ name, condition }) => {
+const UserProfileCard: React.FC<UserProfileCardProps> = ({ profile }) => {
   return (
     <div className='cards' style={cardStyle} >
       <div className='name-circle' style={circleStyle} >
-        <span> {name} </span>
+        <span> {profile.title} </span>
       </div>
       <div className='card-content' style={contentStyle}>
         <div className='profile-name' style={nameStyle}>
-          Condition: {condition}
+          Condition: {profile.condition}
         </div>
-        <Link to='/savedTrials'>
+        <Link to='/editProfile' state={{
+          defaultProfileName: profile.title, 
+          defaultStreet: profile.address.street,
+          defaultCity: profile.address.city,
+          defaultPostalCode: profile.address.postalCode,
+          defaultProvince: profile.address.province, 
+          defaultGender: profile.gender,
+          defaultCondition: profile.condition,
+          defaultDateOfBirth: profile.date_of_birth, 
+          defaultAdvancedInfo: profile.advanced_info,
+          profileId: profile.id}
+        }
+        >
           <div className='saved-trails-link'>
             Edit Profile
           </div>

--- a/src/FE/FEsrc/components/types.tsx
+++ b/src/FE/FEsrc/components/types.tsx
@@ -30,7 +30,7 @@ export interface PatientInfo {
     date_of_birth: string;
     address: Address;
     gender: string;
-    advanced_info: number; // TODO: will be dict of advanced info - must update this type later
+    advanced_info: Object;
     title: string;
     condition: string;
     user: number;

--- a/src/FE/FEsrc/hooks/Validation.ts
+++ b/src/FE/FEsrc/hooks/Validation.ts
@@ -1,8 +1,8 @@
 import e from 'express';
 import { useState, useEffect } from 'react';
 
-export const fieldValidation = (validationFunction, validationTimout = 100) => {
-    const [value, setValue] = useState('');
+export const fieldValidation = (validationFunction, defaultValue='', validationTimout = 100) => {
+    const [value, setValue] = useState(defaultValue);
     const [touched, setTouched] = useState(false);
     const [validated, setValidated] = useState(false);
     const [valid, setValid] = useState(false);

--- a/src/FE/FEsrc/pages/EditProfilePage.tsx
+++ b/src/FE/FEsrc/pages/EditProfilePage.tsx
@@ -1,0 +1,16 @@
+import ProfileCreationPage from "./ProfileCreation";
+import { useLocation } from 'react-router';
+
+const EditProfilePage = (props) => {
+
+    const data = useLocation();
+
+    props = {...data.state, editing: true};
+
+    return (
+        ProfileCreationPage(props)
+    )
+
+}
+
+export default EditProfilePage;

--- a/src/FE/FEsrc/pages/ListProfiles.tsx
+++ b/src/FE/FEsrc/pages/ListProfiles.tsx
@@ -6,6 +6,7 @@ import UserDataCard from '../components/UserDataCard';
 import styled from '@emotion/styled';
 import { Button } from '@mui/material';
 import { StyledButton } from '../components/ButtonStyle';
+import { PatientInfo } from '../components/types';
 
 const AccountProfilePageContainer = styled.div`
     display: flex;
@@ -38,12 +39,6 @@ const SizedButton = styled(StyledButton)`
     margin-left: 4em;
 `;
 
-
-interface PatientProfile {
-  title: string;
-  condition: string;
-}
-
 interface UserData {
   first_name: string;
   last_name: string;
@@ -53,7 +48,7 @@ interface UserData {
 const ListProfiles: React.FC = () => {
 
   const userId = localStorage.getItem('userId') ? localStorage.getItem('userId') : 1;
-  const [profiles, setProfiles] = useState<PatientProfile[]>([]);
+  const [profiles, setProfiles] = useState<PatientInfo[]>([]);
   const [userData, setUserData] = useState<UserData>({ first_name: 'name', last_name: 'name', created: 'date' });
 
   const fetchProfilesList = () => {
@@ -90,9 +85,9 @@ const ListProfiles: React.FC = () => {
       <ProfileListContainer>
         <Header>Profiles</Header>
         {profiles.map((profile, index) => (
-          <UserProfileCard key={index} name={`${profile.title}`} condition={`${profile.condition}`} />
+          <UserProfileCard key={index} profile={profile} />
         ))}
-        <Link to='/createProfile'>
+        <Link to={`/createProfile`}>
           <SizedButton>Add Profile</SizedButton>
         </Link>
       </ProfileListContainer>

--- a/src/FE/FEsrc/pages/ProfileCreation.tsx
+++ b/src/FE/FEsrc/pages/ProfileCreation.tsx
@@ -13,7 +13,23 @@ const ProfileCreationContainer = styled.div`
     padding: 15px;
 `;
 
-const ProfileCreationPage = () => {
+const defaultProps = {
+    defaultProfileName: "",
+    defaultStreet: "",
+    defaultCity: "",
+    defaultPostalCode: "",
+    defaultProvince: "",
+    defaultDateOfBirth: "",
+    defaultGender: "",
+    defaultCondition: "",
+    editing: false,
+    defaultAdvancedInfo: {}
+};
+
+
+const ProfileCreationPage = (props) => {
+    
+    props = {...defaultProps, ...props};
 
     const userId = localStorage.getItem('userId');
 
@@ -21,32 +37,31 @@ const ProfileCreationPage = () => {
 
     const genderMapping = { 'Male': 'M', 'Female': 'F', 'Other': 'O' };
 
-    const [advancedInfo, setAdvancedInfo] = useState({});
-
+    const [advancedInfo, setAdvancedInfo] = useState(props.defaultAdvancedInfo);
     const [formValues, setFormValues] = useState({
         user: userId,
-        condition: '',
+        condition: props.defaultCondition,
         advancedInfo: advancedInfo
     });
 
-    const nameField = fieldValidation(checkEmpty);
-    const streetField = fieldValidation(checkEmpty);
-    const cityField = fieldValidation(checkEmpty);
-    const provinceField = fieldValidation(checkEmpty);
-    const postalCodeField = fieldValidation(checkEmpty);
-    const dateOfBirthField = fieldValidation(checkEmpty);
-    const genderField = fieldValidation(checkEmpty);
+    const nameField = fieldValidation(checkEmpty, props.defaultProfileName);
+    const streetField = fieldValidation(checkEmpty, props.defaultStreet);
+    const cityField = fieldValidation(checkEmpty, props.defaultCity);
+    const provinceField = fieldValidation(checkEmpty, props.defaultProvince);
+    const postalCodeField = fieldValidation(checkEmpty, props.defaultPostalCode);
+    const dateOfBirthField = fieldValidation(checkEmpty, props.defaultDateOfBirth);
+    const genderField = fieldValidation(checkEmpty, props.defaultGender);
 
     const [error, setError] = useState(false);
 
     const errorMessage = 'Profile creation failed. Please try again.';
 
-    const addressErrorMessage = 'Invalid address, please enter a valid address in the format: street, city, province, postal code';
     const genericErrorMessage = 'This field cannot be empty';
 
     const enableSubmit = nameField.valid && streetField.valid && cityField.valid && provinceField.valid && postalCodeField.valid && dateOfBirthField.valid && genderField.valid;
 
     const createRequestOptions = () => {
+
         const formattedAddress = {
             street: streetField.value,
             city: cityField.value,
@@ -55,7 +70,7 @@ const ProfileCreationPage = () => {
         }
         const mappedGender = genderMapping[genderField.value];
         return {
-            method: 'POST',
+            method: !props.editing ? 'POST': 'PATCH',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 date_of_birth: dateOfBirthField.value,
@@ -73,13 +88,14 @@ const ProfileCreationPage = () => {
         e.preventDefault();
 
         const requestOptions = createRequestOptions();
-
+        const endpoint = !props.editing ? `${API_URL}/patientinfo/`: `${API_URL}/patientinfo/${props.profileId}/`
+        console.log(endpoint);
         try {
-            const response = await fetch(`${API_URL}/patientinfo/`, requestOptions);
+            const response = await fetch(endpoint, requestOptions);
             const data = await response.json();
 
             if (response.ok) {
-                navigate('/');
+                navigate(!props.editing ? '/': '/listprofiles');
             }
             else {
                 setError(true);
@@ -96,7 +112,7 @@ const ProfileCreationPage = () => {
             temp[keys[index]] = fieldVariable.initial;
             return temp;
         })
-        setAdvancedInfo({...advancedInfo, ...temp})
+        setAdvancedInfo({...temp, ...advancedInfo})
     }, [formValues.condition]);
 
     useEffect(() => {
@@ -227,9 +243,10 @@ const ProfileCreationPage = () => {
                             onInputChange={(event, value, reason) => {
                                 setFormValues({ ...formValues, condition: value })
                             }}
+                            defaultValue={formValues.condition}
                             freeSolo={true}
                             options={conditions}
-                            renderInput={(params) => <AutocompleteTextField {...params} label={formValues.condition ? null : "-- Select Condition --"} value={formValues.condition}
+                            renderInput={(params) => <AutocompleteTextField {...params} label={formValues.condition ? null : "-- Select Condition --"} defaultValue={formValues.condition} value={formValues.condition}
                                 onChange={(e) => {
                                     const newCondition = e.target.value;
                                     setFormValues({ ...formValues, condition: newCondition });

--- a/src/FE/FEsrc/pages/RegisterPage.tsx
+++ b/src/FE/FEsrc/pages/RegisterPage.tsx
@@ -42,7 +42,7 @@ const RegisterPage: React.FC = () => {
     };
 
     const emailField = fieldValidation(validateEmail);
-    const usernameField = fieldValidation(validateUsername, 500);
+    const usernameField = fieldValidation(validateUsername, '', 500);
     const passwordField = fieldValidation(checkEmpty);
     const firstNameField = fieldValidation(checkEmpty);
     const lastNameField = fieldValidation(checkEmpty);


### PR DESCRIPTION
- Reused the profilecreation component
- Passing in props to determine if we should pre populate values or not (i.e., if we are editing or not)
- Added the basic functionality to list profiles that will be needed (i.e., upon clicking edit profile, pass the corresponding profile details to the edit profile page via state), but this can be reworked whenever list profiles is completed
