### PR TITLE
I212 change to allow for nested condition variables

### DIFF
--- a/src/FE/FEsrc/components/AdvancedFormField.tsx
+++ b/src/FE/FEsrc/components/AdvancedFormField.tsx
@@ -17,6 +17,7 @@ interface AdvancedFormFieldProps {
     value: any;
     advancedInfo: {};
     setAdvancedInfo: (info: {}) => void;
+    initializeChildFields: (conditionFields: any, keys: string[], prev: {}[]) => void;
 }
 const AdvancedFormField: React.FC<AdvancedFormFieldProps> = ({
     fieldInfo,
@@ -24,6 +25,7 @@ const AdvancedFormField: React.FC<AdvancedFormFieldProps> = ({
     value,
     advancedInfo,
     setAdvancedInfo,
+    initializeChildFields,
 }) => {
 
     return (
@@ -54,7 +56,14 @@ const AdvancedFormField: React.FC<AdvancedFormFieldProps> = ({
                 checked={value}
                 style={{width: 30, height: 30}}
                 onChange={(e) => {
-                    setAdvancedInfo({ ...advancedInfo, [fieldVariable]: e.target.checked})
+                    if (fieldInfo.children && !e.target.checked) {
+                        const initialAdvancedInfoVals = initializeChildFields(Object.values(fieldInfo.children), Object.keys(fieldInfo.children), [])[0];
+                        const temp = {};
+                        initialAdvancedInfoVals && initialAdvancedInfoVals.map((field: any) => {
+                            advancedInfo[Object.keys(field)[0]] = Object.values(field)[0];
+                        })
+                    }
+                    setAdvancedInfo({ ...advancedInfo, [fieldVariable]: e.target.checked});
                 }
                 }
             /> :

--- a/src/FE/FEsrc/components/AdvancedFormField.tsx
+++ b/src/FE/FEsrc/components/AdvancedFormField.tsx
@@ -9,6 +9,7 @@ export interface FieldInfo {
     dropdownOptions: string[] | null;
     clinician: boolean;
     i: string;
+    children: {[key: string]: FieldInfo} | null;
 }
 interface AdvancedFormFieldProps {
     fieldInfo: FieldInfo;
@@ -42,7 +43,7 @@ const AdvancedFormField: React.FC<AdvancedFormFieldProps> = ({
                 value={value}
                 onChange={(e) => setAdvancedInfo({ ...advancedInfo, [fieldVariable]: e.target.value })}
             >
-                <option value='' disabled>{`-- Select ${fieldInfo.label} --`}</option>
+                <option value="" disabled>{`-- Select ${fieldInfo.label} --`}</option>
                 {fieldInfo.dropdownOptions && fieldInfo.dropdownOptions.map((option, index) => (
                     <option key={index} value={option}>{option}</option>
                 ))}

--- a/src/FE/FEsrc/components/AdvancedFormField.tsx
+++ b/src/FE/FEsrc/components/AdvancedFormField.tsx
@@ -58,7 +58,6 @@ const AdvancedFormField: React.FC<AdvancedFormFieldProps> = ({
                 onChange={(e) => {
                     if (fieldInfo.children && !e.target.checked) {
                         const initialAdvancedInfoVals = initializeChildFields(Object.values(fieldInfo.children), Object.keys(fieldInfo.children), [])[0];
-                        const temp = {};
                         initialAdvancedInfoVals && initialAdvancedInfoVals.map((field: any) => {
                             advancedInfo[Object.keys(field)[0]] = Object.values(field)[0];
                         })

--- a/src/FE/FEsrc/constants/ConditionFields.ts
+++ b/src/FE/FEsrc/constants/ConditionFields.ts
@@ -33,13 +33,15 @@ const asthma = {
         inputType: 'checkbox',
         clinician: false,
         i: "current or ex-smoker",
-    },
-    packYears: {
-        label: "Pack-Years",
-        initial: 0,
-        inputType: 'number',
-        clinician: false,
-        i: "number of years you smoked for multiplied by number of cigarettes smoked per day",
+        children: {
+            packYears: {
+            label: "Pack-Years",
+            initial: 0,
+            inputType: 'number',
+            clinician: false,
+            i: "number of years you smoked for multiplied by number of cigarettes smoked per day",
+            },
+        }
     },
     asthmaSeverity: {
         label: "Asthma Severity",
@@ -107,13 +109,15 @@ const copd = {
         inputType: 'checkbox',
         clinician: false,
         i: "current or ex-smoker",
-    },
-    packYears: {
-        label: "Pack-Years",
-        initial: 0,
-        inputType: 'number',
-        clinician: false,
-        i: "number of years you smoked for multiplied by number of cigarettes smoked per day",
+        children: {
+            packYears: {
+            label: "Pack-Years",
+            initial: 0,
+            inputType: 'number',
+            clinician: false,
+            i: "number of years you smoked for multiplied by number of cigarettes smoked per day",
+            },
+        }
     },
     onDualTherapy: {
         label: "On Dual Therapy Inhalers",
@@ -187,13 +191,15 @@ const ild = {
         inputType: 'checkbox',
         clinician: false,
         i: "current or ex-smoker",
-    },
-    packYears: {
-        label: "Pack-Years",
-        initial: 0,
-        inputType: 'number',
-        clinician: false,
-        i: "number of years you smoked for multiplied by number of cigarettes smoked per day",
+        children: {
+            packYears: {
+            label: "Pack-Years",
+            initial: 0,
+            inputType: 'number',
+            clinician: false,
+            i: "number of years you smoked for multiplied by number of cigarettes smoked per day",
+            },
+        }
     },
     pulmonaryHypertension: {
         label: "Co-Existing Pulmonary Hypertension",

--- a/src/FE/FEsrc/constants/ConditionFields.ts
+++ b/src/FE/FEsrc/constants/ConditionFields.ts
@@ -35,11 +35,11 @@ const asthma = {
         i: "current or ex-smoker",
         children: {
             packYears: {
-            label: "Pack-Years",
-            initial: 0,
-            inputType: 'number',
-            clinician: false,
-            i: "number of years you smoked for multiplied by number of cigarettes smoked per day",
+                label: "Pack-Years",
+                initial: 0,
+                inputType: 'number',
+                clinician: false,
+                i: "number of years you smoked for multiplied by number of cigarettes smoked per day",
             },
         }
     },
@@ -111,11 +111,11 @@ const copd = {
         i: "current or ex-smoker",
         children: {
             packYears: {
-            label: "Pack-Years",
-            initial: 0,
-            inputType: 'number',
-            clinician: false,
-            i: "number of years you smoked for multiplied by number of cigarettes smoked per day",
+                label: "Pack-Years",
+                initial: 0,
+                inputType: 'number',
+                clinician: false,
+                i: "number of years you smoked for multiplied by number of cigarettes smoked per day",
             },
         }
     },
@@ -193,11 +193,11 @@ const ild = {
         i: "current or ex-smoker",
         children: {
             packYears: {
-            label: "Pack-Years",
-            initial: 0,
-            inputType: 'number',
-            clinician: false,
-            i: "number of years you smoked for multiplied by number of cigarettes smoked per day",
+                label: "Pack-Years",
+                initial: 0,
+                inputType: 'number',
+                clinician: false,
+                i: "number of years you smoked for multiplied by number of cigarettes smoked per day",
             },
         }
     },

--- a/src/FE/FEsrc/pages/ProfileCreation.tsx
+++ b/src/FE/FEsrc/pages/ProfileCreation.tsx
@@ -144,7 +144,7 @@ const ProfileCreationPage = (props) => {
             field ? temp[Object.keys(field)[0]] = Object.values(field)[0] : null;
             return temp;
         })
-        setAdvancedInfo({ ...temp });
+        setAdvancedInfo({ ...temp, ...advancedInfo });
     }, [formValues.condition]);
 
     useEffect(() => {

--- a/src/FE/FEsrc/pages/ProfileCreation.tsx
+++ b/src/FE/FEsrc/pages/ProfileCreation.tsx
@@ -98,6 +98,7 @@ const ProfileCreationPage = (props) => {
                             value={advancedInfo[keys[index]]}
                             advancedInfo={advancedInfo}
                             setAdvancedInfo={setAdvancedInfo}
+                            initializeChildFields={updateAdvancedInfoOnConditionSelection}
                         />
                         {field?.children && advancedInfo[keys[index]] == true ? recursiveConditionFields(Object.values(field.children), Object.keys(field.children)) : null}
                     </>
@@ -277,13 +278,15 @@ const ProfileCreationPage = (props) => {
                         <AutocompleteInput
                             disablePortal
                             onInputChange={(event, value, reason) => {
-                                setFormValues({ ...formValues, condition: value })
+                                setAdvancedInfo({});
+                                setFormValues({ ...formValues, condition: value });
                             }}
                             defaultValue={formValues.condition}
                             freeSolo={true}
                             options={conditions}
                             renderInput={(params) => <AutocompleteTextField {...params} label={formValues.condition ? null : "-- Select Condition --"} defaultValue={formValues.condition} value={formValues.condition}
                                 onChange={(e) => {
+                                    setAdvancedInfo({});
                                     const newCondition = e.target.value;
                                     setFormValues({ ...formValues, condition: newCondition });
                                 }} />

--- a/src/FE/FEsrc/pages/ProfileCreation.tsx
+++ b/src/FE/FEsrc/pages/ProfileCreation.tsx
@@ -86,6 +86,36 @@ const ProfileCreationPage = (props) => {
         };
     };
 
+    const recursiveConditionFields = (conditionFields: any, keys: string[]) => {
+        return (
+            conditionFields.map((field: FieldInfo, index) => {
+                return (
+                    <>
+                        <AdvancedFormField
+                            key={keys[index]}
+                            fieldInfo={field}
+                            fieldVariable={keys[index]}
+                            value={advancedInfo[keys[index]]}
+                            advancedInfo={advancedInfo}
+                            setAdvancedInfo={setAdvancedInfo}
+                        />
+                        {field?.children && advancedInfo[keys[index]] == true ? recursiveConditionFields(Object.values(field.children), Object.keys(field.children)) : null}
+                    </>
+                )
+            })
+        )
+    }
+
+    const updateAdvancedInfoOnConditionSelection = (conditionFields: any, keys: string[], prev: {}[]) => {
+        return (
+            conditionFields.map((fieldVariable: FieldInfo, index) => {
+                const tempCond = { [keys[index]]: fieldVariable.initial };
+                prev.push(tempCond);
+            return fieldVariable?.children ? updateAdvancedInfoOnConditionSelection(Object.values(fieldVariable.children), Object.keys(fieldVariable.children), prev) : prev;
+            })
+        )
+    }
+
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
 
@@ -108,13 +138,13 @@ const ProfileCreationPage = (props) => {
     };
 
     useEffect(() => {
+        const initialAdvancedInfoVals = Conditions[formValues.condition] ? updateAdvancedInfoOnConditionSelection(Object.values(Conditions[formValues.condition]), Object.keys(Conditions[formValues.condition]), [])[0] : null;
         const temp = {};
-        Conditions[formValues.condition] && Object.values(Conditions[formValues.condition]).map((fieldVariable: { initial: string }, index) => {
-            const keys = Object.keys(Conditions[formValues.condition]);
-            temp[keys[index]] = fieldVariable.initial;
+        initialAdvancedInfoVals && initialAdvancedInfoVals.map((field: any) => {
+            field ? temp[Object.keys(field)[0]] = Object.values(field)[0] : null;
             return temp;
         })
-        setAdvancedInfo({ ...temp, ...advancedInfo })
+        setAdvancedInfo({ ...temp });
     }, [formValues.condition]);
 
     useEffect(() => {
@@ -259,23 +289,9 @@ const ProfileCreationPage = (props) => {
                                 }} />
                             }
                         />
-
+                        
                         {Conditions[formValues.condition] && (
-                            <>
-                                {Object.values(Conditions[formValues.condition]).map((field: FieldInfo, index) => {
-                                    const keys = Object.keys(Conditions[formValues.condition]);
-                                    return (
-                                        <AdvancedFormField
-                                            key={index}
-                                            fieldInfo={field}
-                                            fieldVariable={keys[index]}
-                                            value={advancedInfo[keys[index]]}
-                                            advancedInfo={advancedInfo}
-                                            setAdvancedInfo={setAdvancedInfo}
-                                        />
-                                    )
-                                })}
-                            </>
+                            recursiveConditionFields(Object.values(Conditions[formValues.condition]), Object.keys(Conditions[formValues.condition]))
                         )}
 
                         {error && <ErrorMessage>{errorMessage}</ErrorMessage>}


### PR DESCRIPTION
allows nested condition fields to only be displayed if parent field is true (#212)

bug fixes:
- resets advancedInfo to empty object once condition field is updated
- sets nested condition fields to their initial value if the parent field is set to false