### PR TITLE
I208 upgrade search trials

### DIFF
--- a/src/FE/FEsrc/components/Map.tsx
+++ b/src/FE/FEsrc/components/Map.tsx
@@ -1,29 +1,23 @@
+import {memo} from 'react';
+
 interface MapProps {
     latitude: number;
     longitude: number;
 }
 
-const Map: React.FC<MapProps> = ({latitude, longitude}) => {
-    const Embed = () => { 
-        const currLocation = `https://www.google.com/maps/embed/v1/place?q=${latitude},${longitude}&key=AIzaSyDSRIniLCNxD-WprGLaZjQuCLgOnj2K3D4`
-        return(
-            <div>
-                <iframe 
+const Map = memo((props: MapProps) => {
+    const currLocation = `https://www.google.com/maps/embed/v1/place?q=${props.latitude},${props.longitude}&key=AIzaSyDSRIniLCNxD-WprGLaZjQuCLgOnj2K3D4`
+    return(
+        <div>
+            <iframe 
                     src={currLocation}
                     loading="lazy" 
                     referrerPolicy="no-referrer-when-downgrade" 
                     width="750" 
                     height="450"
                 />
-            </div>
-        );
-    }
-
-    return(
-        <>
-            <Embed />
-        </>
+        </div>
     )
-}
+});
 
 export default Map;

--- a/src/FE/FEsrc/components/TrialCard.tsx
+++ b/src/FE/FEsrc/components/TrialCard.tsx
@@ -8,20 +8,24 @@ interface TrialProps {
     setCurrentLocation: (location: Object) => void;
     handleModal: () => void;
     setModalDetails: (details: Object) => void;
+    trialNumber: number;
+    isSelected: Object;
+    setIsSelected: (isSelected: Object) => void;
 }
 
-const TrialCard: React.FC<TrialProps> = ({ trial, trialSaved, handleSave, setCurrentLocation, handleModal, setModalDetails }) => {
+const TrialCard: React.FC<TrialProps> = ({ trial, trialSaved, handleSave, setCurrentLocation, handleModal, setModalDetails, trialNumber, isSelected, setIsSelected }) => {
     return (
-        <TrialContainer key={trial.NCTId}>
+        <TrialContainer key={trial.NCTId} style={{backgroundColor: isSelected[trial.NCTId] ? '#6495ED': '#38569A'}}>
             <TrialDescription>
                 <TrialTitle
                     onClick={(e) => {
                         e.preventDefault();
                         setCurrentLocation({ latitude: trial.LocationLatitude, longitude: trial.LocationLongitude });
+                        setIsSelected({[trial.NCTId]: true});
                     }
                     }
                 >
-                    {trial.BriefTitle}
+                    {trialNumber + '. ' + trial.BriefTitle}
                 </TrialTitle>
 
                 <p><u style={{ color: 'white' }}><a onClick={() => {

--- a/src/FE/FEsrc/components/TrialCard.tsx
+++ b/src/FE/FEsrc/components/TrialCard.tsx
@@ -15,7 +15,7 @@ interface TrialProps {
 
 const TrialCard: React.FC<TrialProps> = ({ trial, trialSaved, handleSave, setCurrentLocation, handleModal, setModalDetails, trialNumber, isSelected, setIsSelected }) => {
     return (
-        <TrialContainer key={trial.NCTId} style={{backgroundColor: isSelected[trial.NCTId] ? '#6495ED': '#38569A'}}>
+        <TrialContainer key={trial.NCTId} style={{backgroundColor: isSelected[trial.NCTId] ? '#021691': '#38569A'}}>
             <TrialDescription>
                 <TrialTitle
                     onClick={(e) => {

--- a/src/FE/FEsrc/components/TrialCardStyle.tsx
+++ b/src/FE/FEsrc/components/TrialCardStyle.tsx
@@ -2,12 +2,14 @@ import styled from '@emotion/styled';
 
 export const TrialContainer = styled.div`
     width: 570px;
-    background-color: #38569A;
     border-radius: 20px;
     padding: 15px;
     display: flex;
     justify-content: space-between;
     margin-bottom: 15px;
+    &:hover {
+        background-color: #6495ED !important;
+    }
 `;
 
 export const TrialTitle = styled.b`

--- a/src/FE/FEsrc/components/TrialCardStyle.tsx
+++ b/src/FE/FEsrc/components/TrialCardStyle.tsx
@@ -8,7 +8,7 @@ export const TrialContainer = styled.div`
     justify-content: space-between;
     margin-bottom: 15px;
     &:hover {
-        background-color: #6495ED !important;
+        background-color: #021691 !important;
     }
 `;
 

--- a/src/FE/FEsrc/pages/SavedTrialsPage.tsx
+++ b/src/FE/FEsrc/pages/SavedTrialsPage.tsx
@@ -44,7 +44,7 @@ const EmptyResponse = styled.div`
     z-index: 9999;
     font-size: 30px;
     color: white;
-`
+`;
 
 const SaveTrialsPage = () => {
 

--- a/src/FE/FEsrc/pages/TrialSearchPage.tsx
+++ b/src/FE/FEsrc/pages/TrialSearchPage.tsx
@@ -274,7 +274,6 @@ const TrialSearchPage = () => {
 
     const nextPage = (e) => {
         if (responseTrials && currentTrialCount <= currentTrialPointer) {
-            console.log("next page");
             const numTrials = Object.keys(responseTrials).length;
             const nextPage = responseTrials[numTrials-1].nextPage;
             setPageToken(nextPage);
@@ -291,16 +290,8 @@ const TrialSearchPage = () => {
     const updatePageDetails = () => {
         const currNumTrials = responseTrials ? Object.keys(responseTrials).length: 0;
         setCurrentTrialCount(currNumTrials);
-
-
-        console.log(currentTrialPointer);
-        console.log(Math.min(trialBatchDisplaySize, currNumTrials-currentTrialPointer));
-
         const currTrialPointer = responseTrials ? currentTrialPointer + Math.min(trialBatchDisplaySize, currNumTrials-currentTrialPointer): 0;
         setCurrentTrialPointer(currTrialPointer);
-        console.log("curr num trials" + currNumTrials);
-        console.log(responseTrials);
-        console.log(currTrialPointer);
     }
     
     const resetPageDetails = () => {
@@ -420,8 +411,8 @@ const TrialSearchPage = () => {
             {loading && !responseTrials ? <Loading> <CircularProgress size="5rem" color="success" /> </Loading> : <div style={{ display: 'flex' }}>
                 <TrialsListContainer>
                     {displayTrials()}
-                    {responseTrials && !loading && hasNextPage && <StyledButton onClick={e => { nextPage(e); }}>More Trials</StyledButton>}
-                    {responseTrials && !loading && !hasNextPage && <StyledButton style={{backgroundColor: '#A5A5A5', cursor: 'default'}} disabled>Sorry, No More Trials!</StyledButton>}
+                    {responseTrials && !loading && (hasNextPage || currentTrialPointer < currentTrialCount) && <StyledButton onClick={e => { nextPage(e); }}>More Trials</StyledButton>}
+                    {responseTrials && !loading && !(hasNextPage || currentTrialPointer < currentTrialCount) && <StyledButton style={{backgroundColor: '#A5A5A5', cursor: 'default'}} disabled>Sorry, No More Trials!</StyledButton>}
                     {responseTrials && loading && <CircularProgress size="1rem" color="success" />}
                 </TrialsListContainer>
                 <MapContainer>

--- a/src/FE/FEsrc/pages/TrialSearchPage.tsx
+++ b/src/FE/FEsrc/pages/TrialSearchPage.tsx
@@ -54,7 +54,10 @@ const Loading = styled.div`
     z-index: 9999;    
 `;
 
-const TrialSearchPage = () => {
+const trialBatchFetchSize = 5;
+const trialBatchDisplaySize = 3;
+
+const TrialSearchPage = () => {    
     const navigate = useNavigate();
     const [responseProfiles, setResponseProfiles] = useState<PatientInfoList | null>(null);
     const [responseTrials, setResponseTrials] = useState<TrialInfoList | null>(null);
@@ -69,6 +72,7 @@ const TrialSearchPage = () => {
     const [maxDistance, setMaxDistance] = useState('');
     const [profileError, setProfileError] = useState(false);
     const [currentTrialCount, setCurrentTrialCount] = useState(0);
+    const [currentTrialPointer, setCurrentTrialPointer] = useState(trialBatchDisplaySize);
     const [pageToken, setPageToken] = useState('');
     const [open, setOpen] = useState(false);
     const [modalDetails, setModalDetails] = useState({
@@ -270,12 +274,12 @@ const TrialSearchPage = () => {
         console.log(currentTrialCount);
         console.log(responseTrials);
         if (responseTrials) {
-            const nextPage = responseTrials[currentTrialCount-1].nextPage;
-            setPageTokens([...pageTokens, nextPage]);
-            setPageTokenPointer(pageTokenPointer + 1);
-            
+            if(currentTrialCount <= currentTrialPointer){
+                const nextPage = responseTrials[currentTrialCount-1].nextPage;
+                setPageToken(nextPage);
+            }
             // actual
-            setPageToken(nextPage);
+            setCurrentTrialPointer(currentTrialPointer + trialBatchDisplaySize);
         }
     }
 
@@ -303,7 +307,7 @@ const TrialSearchPage = () => {
     const displayTrials = () => {
         return (
             responseTrials &&
-            Object.values(responseTrials).map((trial) => (
+            Object.values(responseTrials).filter((_, index) => index < currentTrialPointer).map((trial) => (
                 <TrialCard
                     trial={trial}
                     trialSaved={trialSaved}
@@ -335,7 +339,7 @@ const TrialSearchPage = () => {
 
     useDidMountEffect(() => {
         fetchTrials();
-    }, [pageTokenPointer]);
+    }, [pageToken]);
 
     const navigateToBookmarks = () => {
         navigate('/savedTrials');

--- a/src/backend/reach_backend/Api/trial_fetcher.py
+++ b/src/backend/reach_backend/Api/trial_fetcher.py
@@ -11,7 +11,7 @@ locator = Nominatim(user_agent="my_request")
 
 API_URL2 = (
     r"https://clinicaltrials.gov/api/v2/studies?format=json&countTotal=true&filter.overallStatus=RECRUITING&"
-    r"fields=NCTId,Condition,BriefTitle,DetailedDescription,"
+    r"fields=NCTId,Condition,BriefTitle,DetailedDescription,BriefSummary,"
     r"MinimumAge,MaximumAge,LocationGeoPoint,LocationCountry,LocationState,"
     r"LocationCity,LocationZip,OverallStatus,Gender,Keyword,"
     r"PointOfContactEMail,CentralContactEMail,ResponsiblePartyInvestigatorFullName,"
@@ -181,6 +181,8 @@ def build_study_dict(response):
         conditions = study_conditions_module.get("conditions", [])
         keywords = study_conditions_module.get("keywords", [])
         description = description_module.get("detailedDescription", "")
+        if not description:
+            description = description_module.get("briefSummary", "")
         min_age = eligibility_module.get("minimumAge", "0 Years")
         max_age = eligibility_module.get("maximumAge", "100 Years")
         gender = eligibility_module.get("sex", "ALL")

--- a/src/backend/reach_backend/Api/views.py
+++ b/src/backend/reach_backend/Api/views.py
@@ -179,7 +179,8 @@ def search_trials(request):
         info_profile=info_profile, next_page=next_page, max_distance=max_distance
     )
     trials = trial_fetcher.search_studies(trial_input_info)
-
+    if(not isinstance(trials, dict)):
+        return Response(json.dumps(None))
     # saved trials attached to current search profile
     saved_trials = Trial.objects.values_list("nctid", flat=True).filter(user=user_id)
 


### PR DESCRIPTION
- Indicate when a trial is selected/hovered (just chose a random style rn)
- Add load more trials instead of prev/next page (note: didn't bother styling loading symbol, figured @deep123845  would end up changing it when he does the styling changes)
- Ability to fetch any chunk of trials, but still only render a subset of those trials (rn just fetching 5, and rendering 3 of the 5, then 2, then 3, etc... if we were fetching 20, we could easily render 5 each time, or any number less than 20)
- Add brief description if detailed description is not present
- Fix map rendering each time something is selected