### PR TITLE
Frontend adjustments based on feedback

### DIFF
--- a/src/FE/FEsrc/components/App.tsx
+++ b/src/FE/FEsrc/components/App.tsx
@@ -32,7 +32,7 @@ function App() {
                     <Route path='/contact' element={<ContactUsPage />} />
                     <Route path='/faq' element={<FAQPage />} />
                     <Route path='/search' element={<TrialSearchPage />} />
-                    <Route path='/savedTrials' element={<SaveTrialsPage />} />
+                    <Route path='/savedStudies' element={<SaveTrialsPage />} />
                     <Route path='/createProfile' element={<ProfileCreationPage />} />
                     <Route path='/accountProfile' element={<EditAccountInfoPage />} />
                     <Route path='/listprofiles' element={<ListProfiles />} />

--- a/src/FE/FEsrc/components/Map.tsx
+++ b/src/FE/FEsrc/components/Map.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 const StyledMap = styled.iframe`
     width: calc(100vw - 657px);
     min-width: 600px;
-    height: calc(95vh - 235px);
+    height: calc(95vh - 295px);
     border: 0;
     allowfullscreen;
     loading: lazy;

--- a/src/FE/FEsrc/components/MenuHeader.tsx
+++ b/src/FE/FEsrc/components/MenuHeader.tsx
@@ -337,11 +337,11 @@ const MenuHeader: React.FC = () => {
                             <AccountIcon />
                         </AccountCircle>
                         <AccountDropdown isopen={isOpenAcc} ref={dropdownListRefAcc}>
-                            <DropdownLink to='/savedTrials'>
+                            <DropdownLink to='/savedStudies'>
                                 <Tooltip title='Saved Trials'>
                                     <DropDownInput>
                                         <FilledBookmarkIcon />
-                                        <DropdownText>Saved Trials</DropdownText>
+                                        <DropdownText>Saved Studies</DropdownText>
                                     </DropDownInput>
                                 </Tooltip>
                             </DropdownLink>

--- a/src/FE/FEsrc/components/MenuHeader.tsx
+++ b/src/FE/FEsrc/components/MenuHeader.tsx
@@ -111,7 +111,7 @@ const DropdownText = styled.p`
 `;
 
 const AccountDropdown = styled.ul<AccountDropdownProps>`
-    position: absolute;
+    position: fixed;
     padding: 0;
     top: 80px;
     right: 40px;

--- a/src/FE/FEsrc/pages/LandingPage.tsx
+++ b/src/FE/FEsrc/pages/LandingPage.tsx
@@ -66,6 +66,10 @@ const LandingPage = () => {
         isAuthenticated ? navigate('/search') : navigate('/login');
     };
 
+    const navigateToProfiles = () => {
+        isAuthenticated ? navigate('/listprofiles') : navigate('/login');
+    };
+
     useEffect(() => {
         checkLoginSuccess();
         checkProfileSuccess();
@@ -96,6 +100,7 @@ const LandingPage = () => {
             </LandingPageText>
             <PortalButtonsContainer>
                 <PortalButtons type='button' onClick={navigateToSearch}>REACH Portal</PortalButtons>
+                <PortalButtons type='button' onClick={navigateToProfiles}>Profiles</PortalButtons>
             </PortalButtonsContainer>
         </LandingPageContainer >
     );

--- a/src/FE/FEsrc/pages/LandingPage.tsx
+++ b/src/FE/FEsrc/pages/LandingPage.tsx
@@ -40,22 +40,22 @@ const LandingPage = () => {
     const { isAuthenticated } = useAuth();
 
     const checkLoginSuccess = () => {
-        if(localStorage.getItem('openLoginSnack')) {
+        if (localStorage.getItem('openLoginSnack')) {
             setIsLoginSnackBarOpen(true);
             localStorage.removeItem('openLoginSnack');
         }
     }
 
     const checkProfileSuccess = () => {
-        if(localStorage.getItem('openProfileSnack')) {
-            if(localStorage.getItem('firstProfileCreated')){
+        if (localStorage.getItem('openProfileSnack')) {
+            if (localStorage.getItem('firstProfileCreated')) {
                 setIsFirstProfileSnackBarOpen(true);
                 localStorage.removeItem('firstProfileCreated');
             }
-            else{
+            else {
                 setIsProfileSnackBarOpen(true);
             }
-        
+
             localStorage.removeItem('openProfileSnack');
         }
     }
@@ -89,16 +89,13 @@ const LandingPage = () => {
                 snackText={"Profile Created Successfully! You can now visit the reach portal and begin searching for trials."}
             />
             <LandingPageText>
-                <p>Looking for opportunities to participate in a clinical trial or research study? REACH can match
-                    you to relevant clinical trials based on some basic information about you.</p>
+                <p>Looking for opportunities to participate in a clinical trial or research study? REACH can find
+                    you relevant studies based on some basic information about you.</p>
                 <p>REACH can be used by both patients and clinicians.</p>
-                <p>Note: Currently many values are placeholders. As this is a low-fidelity prototype we are mainly
-                    mocking the UI as well as the primary functionality of the application.</p>
-                <p>If you are new to REACH, click on one of the buttons to get started.</p>
+                <p>If you are new to REACH, click on the REACH Portal button.</p>
             </LandingPageText>
             <PortalButtonsContainer>
                 <PortalButtons type='button' onClick={navigateToSearch}>REACH Portal</PortalButtons>
-                <PortalButtons style={{ visibility: 'hidden' }}>Clinician Portal</PortalButtons>
             </PortalButtonsContainer>
         </LandingPageContainer >
     );

--- a/src/FE/FEsrc/pages/ProfileCreation.tsx
+++ b/src/FE/FEsrc/pages/ProfileCreation.tsx
@@ -32,7 +32,7 @@ const defaultProps = {
 const ProfileCreationPage = (props) => {
 
     props = { ...defaultProps, ...props };
-    
+
     const [isRegistrationSnackOpen, setIsRegistrationSnackOpen] = useState(false);
 
     const userId = localStorage.getItem('userId');
@@ -94,7 +94,7 @@ const ProfileCreationPage = (props) => {
 
     function indexOfMax(arr) {
         if (arr.length === 0) return -1;
-    
+
         return arr.reduce((maxIndex, currentArray, currentIndex, array) => {
             return currentArray.length > array[maxIndex].length ? currentIndex : maxIndex;
         }, 0);
@@ -118,7 +118,7 @@ const ProfileCreationPage = (props) => {
                             indexOfMax={indexOfMax}
                             margin={margin}
                         />
-                        {field?.children && recursionCondition ? recursiveConditionFields(Object.values(field.children), Object.keys(field.children), margin+25) : null}
+                        {field?.children && recursionCondition ? recursiveConditionFields(Object.values(field.children), Object.keys(field.children), margin + 25) : null}
                     </React.Fragment>
                 )
             })
@@ -126,7 +126,7 @@ const ProfileCreationPage = (props) => {
     }
 
     const checkJustRegistered = () => {
-        if(localStorage.getItem('justRegistered')) {
+        if (localStorage.getItem('justRegistered')) {
             setIsRegistrationSnackOpen(true);
             localStorage.removeItem('justRegistered');
             localStorage.setItem('firstProfileCreated', "true");
@@ -140,7 +140,7 @@ const ProfileCreationPage = (props) => {
                     const tempCond = { [keys[index]]: fieldVariable.initial };
                     prev.push(tempCond);
                 }
-                
+
                 return fieldVariable?.children ? updateAdvancedInfoOnConditionSelection(Object.values(fieldVariable.children), Object.keys(fieldVariable.children), prev) : prev;
             })
         )
@@ -158,7 +158,7 @@ const ProfileCreationPage = (props) => {
 
             if (response.ok) {
                 localStorage.setItem('openProfileSnack', "true");
-                navigate(!props.editing ? '/' : '/listprofiles'); 
+                navigate(!props.editing ? '/' : '/listprofiles');
             }
             else {
                 setError(true);
@@ -200,11 +200,11 @@ const ProfileCreationPage = (props) => {
     return (
         <>
             <ProfileCreationContainer>
-            <CustomizedSnackbars
-                isOpen={isRegistrationSnackOpen}
-                setIsOpen={setIsRegistrationSnackOpen}
-                snackText={"Account Registered Successfully!"}
-            />
+                <CustomizedSnackbars
+                    isOpen={isRegistrationSnackOpen}
+                    setIsOpen={setIsRegistrationSnackOpen}
+                    snackText={"Account Registered Successfully!"}
+                />
                 <FormContainer>
                     {!props.editing && isClinician == "true" && <FormTitle>New Patient Profile</FormTitle>}
                     {!props.editing && isClinician == "false" && <FormTitle>New Search Profile</FormTitle>}
@@ -314,6 +314,7 @@ const ProfileCreationPage = (props) => {
                         <FormLabel>Date of Birth</FormLabel>
                         <TextInput
                             type='date'
+                            max='9999-12-31'
                             id='date of birth'
                             value={dateOfBirthField.value}
                             onChange={dateOfBirthField.handleChange}
@@ -351,7 +352,7 @@ const ProfileCreationPage = (props) => {
                                 }} />
                             }
                         />
-                        
+
                         {Conditions[formValues.condition] && (
                             recursiveConditionFields(Object.values(Conditions[formValues.condition]), Object.keys(Conditions[formValues.condition]), 0)
                         )}

--- a/src/FE/FEsrc/pages/ProfileCreation.tsx
+++ b/src/FE/FEsrc/pages/ProfileCreation.tsx
@@ -103,7 +103,7 @@ const ProfileCreationPage = (props) => {
     const recursiveConditionFields = (conditionFields: any, keys: string[], margin: number) => {
         return (
             conditionFields.map((field: FieldInfo, index) => {
-                const displayCondition = !(isClinician == "false" && field.clinician);
+                const displayCondition = ((isClinician == "true") == field.clinician);
                 const recursionCondition = advancedInfo[keys[index]] == true || keys[index]?.includes("SUBHEADER");
                 return displayCondition && (
                     <React.Fragment key={keys[index]}>

--- a/src/FE/FEsrc/pages/SavedTrialsPage.tsx
+++ b/src/FE/FEsrc/pages/SavedTrialsPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { API_URL } from '..';
 import { PatientInfo, SavedTrial } from '../components/types';
@@ -6,6 +7,7 @@ import SavedTrialCard from '../components/SavedTrialCard';
 import { DropDownInput } from '../components/FormStyles';
 import Map from '../components/Map';
 import TrialModal from '../components/TrialModal';
+import { StyledButton } from '../components/ButtonStyle';
 
 const TrialsListContainer = styled.div`
     padding: 10px;
@@ -31,8 +33,14 @@ const TrialSearchHeader = styled.div`
 
 const StyledDropDown = styled(DropDownInput)`
     margin: 10px;
-    width: 400px;
+    width: 300px;
     height: 55px;
+`;
+
+const SizedButton = styled(StyledButton)`
+    height: 55px;
+    margin: 10px;
+    padding: 5px 15px;
 `;
 
 const EmptyResponse = styled.div`
@@ -65,6 +73,7 @@ const PageContainer = styled.div`
 
 const SaveTrialsPage = () => {
 
+    const navigate = useNavigate();
     const userId = localStorage.getItem('userId');
     const [trials, setTrials] = useState<SavedTrial[]>([]);
     const [loading, setLoading] = useState(false);
@@ -205,6 +214,10 @@ const SaveTrialsPage = () => {
         setUpdateDefault(false);
     }
 
+    const navigateToProfiles = () => {
+        navigate('/listprofiles');
+    };
+
     useEffect(() => {
         setAuthToken(localStorage.getItem('accessToken'));
     }, [localStorage.getItem('accessToken')]);
@@ -259,6 +272,7 @@ const SaveTrialsPage = () => {
                         ))
                     }
                 </StyledDropDown>
+                <SizedButton type='button' onClick={navigateToProfiles}>Profiles</SizedButton>
             </TrialSearchHeader>
 
             {(trials.length == 0 && !loading) ? <EmptyResponse>No Trials Found!</EmptyResponse> : <ResultContainer>

--- a/src/FE/FEsrc/pages/SavedTrialsPage.tsx
+++ b/src/FE/FEsrc/pages/SavedTrialsPage.tsx
@@ -275,7 +275,7 @@ const SaveTrialsPage = () => {
                 <SizedButton type='button' onClick={navigateToProfiles}>Profiles</SizedButton>
             </TrialSearchHeader>
 
-            {(trials.length == 0 && !loading) ? <EmptyResponse>No Trials Found!</EmptyResponse> : <ResultContainer>
+            {(trials.length == 0 && !loading) ? <EmptyResponse>No Studies Found!</EmptyResponse> : <ResultContainer>
                 <TrialsListContainer>
                     {displayTrials()}
                 </TrialsListContainer>

--- a/src/FE/FEsrc/pages/TrialSearchPage.tsx
+++ b/src/FE/FEsrc/pages/TrialSearchPage.tsx
@@ -24,7 +24,7 @@ const TrialSearchHeader = styled.div`
 
 const StyledDropDown = styled(DropDownInput)`
     margin: 10px;
-    width: 400px;
+    width: 300px;
     height: 55px;
 `;
 
@@ -388,6 +388,10 @@ const TrialSearchPage = () => {
         navigate('/savedTrials');
     };
 
+    const navigateToProfiles = () => {
+        navigate('/listprofiles');
+    };
+
     return (
         <PageContainer>
             <TrialSearchHeader>
@@ -437,23 +441,26 @@ const TrialSearchPage = () => {
                     fetchTrials(false);
                 }}>Search</SizedButton>
                 <SizedButton type='button' onClick={navigateToBookmarks}>View Bookmarks</SizedButton>
+                <SizedButton type='button' onClick={navigateToProfiles}>Profiles</SizedButton>
             </TrialSearchHeader>
 
-            {loading && !responseTrials ? <Loading> <CircularProgress size="5rem" color="success" /> </Loading> : <ResultContainer>
-                <TrialsListContainer>
-                    {displayTrials()}
-                    {responseTrials && !loading && (hasNextPage || currentTrialPointer < currentTrialCount) && <StyledButton onClick={e => { nextPage(e); }}>More Trials</StyledButton>}
-                    {responseTrials && !loading && !(hasNextPage || currentTrialPointer < currentTrialCount) && <StyledButton style={{ backgroundColor: '#A5A5A5', cursor: 'default' }} disabled>Sorry, No More Trials!</StyledButton>}
-                    {responseTrials && loading && <CircularProgress size="1rem" color="success" />}
-                </TrialsListContainer>
-                <MapContainer>
-                    {(responseTrials) && <Map latitude={currentLocation["latitude"]} longitude={currentLocation["longitude"]} />}
-                </MapContainer>
-            </ResultContainer>}
+            {
+                loading && !responseTrials ? <Loading> <CircularProgress size="5rem" color="success" /> </Loading> : <ResultContainer>
+                    <TrialsListContainer>
+                        {displayTrials()}
+                        {responseTrials && !loading && (hasNextPage || currentTrialPointer < currentTrialCount) && <StyledButton onClick={e => { nextPage(e); }}>More Trials</StyledButton>}
+                        {responseTrials && !loading && !(hasNextPage || currentTrialPointer < currentTrialCount) && <StyledButton style={{ backgroundColor: '#A5A5A5', cursor: 'default' }} disabled>Sorry, No More Trials!</StyledButton>}
+                        {responseTrials && loading && <CircularProgress size="1rem" color="success" />}
+                    </TrialsListContainer>
+                    <MapContainer>
+                        {(responseTrials) && <Map latitude={currentLocation["latitude"]} longitude={currentLocation["longitude"]} />}
+                    </MapContainer>
+                </ResultContainer>
+            }
 
             <TrialModal open={open} handleModal={handleModal} modalDetails={modalDetails} patientDetails={getProfile(selectedProfileId)} name={name} />
 
-        </PageContainer>
+        </PageContainer >
     );
 }
 

--- a/src/FE/FEsrc/pages/TrialSearchPage.tsx
+++ b/src/FE/FEsrc/pages/TrialSearchPage.tsx
@@ -22,6 +22,14 @@ const TrialSearchHeader = styled.div`
     align-items: center;
 `;
 
+const AccountHeader = styled.div`
+    background-color: #173A76;
+    min-width: 100%;
+    height: 65px;
+    display: inline-flex;
+    align-items: center;
+`;
+
 const StyledDropDown = styled(DropDownInput)`
     margin: 10px;
     width: 300px;
@@ -40,7 +48,7 @@ const SizedButton = styled(StyledButton)`
 
 const TrialsListContainer = styled.div`
     padding: 10px;
-    height: calc(95vh - 235px);
+    height: calc(95vh - 295px);
     overflow-y: auto;
     max-width: 750px;
     overflow-x: hidden;
@@ -385,7 +393,7 @@ const TrialSearchPage = () => {
     }, [responseTrials]);
 
     const navigateToBookmarks = () => {
-        navigate('/savedTrials');
+        navigate('/savedStudies');
     };
 
     const navigateToProfiles = () => {
@@ -394,6 +402,10 @@ const TrialSearchPage = () => {
 
     return (
         <PageContainer>
+            <AccountHeader>
+                <SizedButton type='button' onClick={navigateToBookmarks}>Saved Studies</SizedButton>
+                <SizedButton type='button' onClick={navigateToProfiles}>Profiles</SizedButton>
+            </AccountHeader>
             <TrialSearchHeader>
                 <StyledDropDown
                     value={selectedProfileId}
@@ -440,16 +452,14 @@ const TrialSearchPage = () => {
                     resetPageDetails();
                     fetchTrials(false);
                 }}>Search</SizedButton>
-                <SizedButton type='button' onClick={navigateToBookmarks}>View Bookmarks</SizedButton>
-                <SizedButton type='button' onClick={navigateToProfiles}>Profiles</SizedButton>
             </TrialSearchHeader>
 
             {
                 loading && !responseTrials ? <Loading> <CircularProgress size="5rem" color="success" /> </Loading> : <ResultContainer>
                     <TrialsListContainer>
                         {displayTrials()}
-                        {responseTrials && !loading && (hasNextPage || currentTrialPointer < currentTrialCount) && <StyledButton onClick={e => { nextPage(e); }}>More Trials</StyledButton>}
-                        {responseTrials && !loading && !(hasNextPage || currentTrialPointer < currentTrialCount) && <StyledButton style={{ backgroundColor: '#A5A5A5', cursor: 'default' }} disabled>Sorry, No More Trials!</StyledButton>}
+                        {responseTrials && !loading && (hasNextPage || currentTrialPointer < currentTrialCount) && <StyledButton onClick={e => { nextPage(e); }}>More Studies</StyledButton>}
+                        {responseTrials && !loading && !(hasNextPage || currentTrialPointer < currentTrialCount) && <StyledButton style={{ backgroundColor: '#A5A5A5', cursor: 'default' }} disabled>Sorry, No More Studies!</StyledButton>}
                         {responseTrials && loading && <CircularProgress size="1rem" color="success" />}
                     </TrialsListContainer>
                     <MapContainer>


### PR DESCRIPTION
Made some adjustments to the frontend based on the following feedback:

> There is redundancy in the variables for when someone is a clinician because they are seeing the patient and clinician variables. So there are two questions asking the exact same thing for a few of the variables. I want the clinician just to see the listed “clinician facing” variables, and the patient to just see the “patient facing” variables.
> 
> Everywhere it says “trials” should be “studies”; not everything is a clinical trial, some are other types of research studies.
> 
> Can we separate “Patient Profiles” from the top right profile icon, and put it under “REACH Portal”?
> 
> Date of birth issues with year being 6 numbers still present.

Also adjusted the search page to separate account and search related buttons in the search header.

Slight change to homepage text.